### PR TITLE
build: always exec xargs command

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,5 +3,5 @@
 files=$(git diff --cached --name-only --diff-filter=AM | grep '.swift$')
 if [[ -n $files ]]; then
    swift-format -ir $files
-   echo $files | xargs -r git add
+   echo $files | xargs git add
 fi


### PR DESCRIPTION
The `-r` flag is GNU standard; the builtin macOS `xargs` does not support it.
The flag instructs xargs to only run its command when arguments are present.
We're already checking that `$flags` is nonempty, so it should be safe to remove
this additional check.