### PR TITLE
build: remove swiftlint from setup

### DIFF
--- a/Setup.swift
+++ b/Setup.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let setup = Setup([
-  .homebrew(packages: ["swift-format", "swiftlint"]),
+  .homebrew(packages: ["swift-format"]),
   .custom(
     name: "git hooks",
     meet: ["./scripts/install-hooks.sh"],


### PR DESCRIPTION
This is an unfortunate workaround for an error that's blocking #6. The machines
provided by GitHub appear to come preinstalled with swiftlint, which makes brew
choke when creating the symlinks because they're already present. We aren't able
to change how Tuist invokes brew, so the only thing we can do is remove the
dependency from our Setup and remember to manually install the package on our
local machines.

https://github.com/caipre/point-free-wg/pull/6#issuecomment-763103176