### PR TITLE
build: remove setup from workflow

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -17,9 +17,6 @@ jobs:
       - name: Install Tuist
         run: |
           bash <(curl -Ls https://install.tuist.io)
-      - name: Setup
-        run: |
-          tuist up
       - name: Build App
         run: |
           tuist build App


### PR DESCRIPTION
The current Setup.swift supports local development by installing needed
dependencies and a useful git hook. These are unnecessary to build the actual
project, though. Because of errors we encountered in #6, we'll drop this step
from the workflow until it's actually necessary for the build.

https://github.com/caipre/point-free-wg/pull/6#issuecomment-763103176