### PR TITLE
feat: composablearchitecture module with pullback

### DIFF
--- a/ComposableArchitecture/App/Sources/Home/HomeView.swift
+++ b/ComposableArchitecture/App/Sources/Home/HomeView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct HomeView: View {
   @ObservedObject var store: Store<AppState, AppAction>
   @State private var selection: Language = .en
-  //  @State private var searchQuery: String = ""
 
   var body: some View {
     NavigationView {

--- a/ComposableArchitecture/App/Sources/WordDefinition/WordDefinitionView.swift
+++ b/ComposableArchitecture/App/Sources/WordDefinition/WordDefinitionView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct WordDefinitionView: View {
   var body: some View {
-    VStack() {
+    VStack {
       HStack {
         Text("Word")
         Button("*") {

--- a/ComposableArchitecture/ComposableArchitecture/Sources/Pullback.swift
+++ b/ComposableArchitecture/ComposableArchitecture/Sources/Pullback.swift
@@ -1,0 +1,47 @@
+import CasePaths
+import Foundation
+
+/// An optic is "a composable notion of substructure." There are many types of
+/// optics; here we declare the protocols for two common optics that we will
+/// make use of throughout the ComposableArchitecture. A Lens describes how to
+/// transform a superstructure into its component parts (and back again). A
+/// Prism distinguishes a particular case from its variants (and back again).
+/// https://hackage.haskell.org/package/optics-0.1/docs/Optics.html
+public enum Optics {
+  // The Swift compiler provides Lenses for structs as KeyPaths
+  public struct Lens<GlobalValue, LocalValue> {
+    public let get: (GlobalValue) -> LocalValue
+    public let set: (LocalValue, inout GlobalValue) -> Void
+  }
+
+  // The CasePaths library provides Prisms for enums via reflection
+  public struct Prism<GlobalAction, LocalAction> {
+    public let extract: (GlobalAction) -> LocalAction?
+    public let embed: (LocalAction) -> GlobalAction
+  }
+}
+
+public enum Pullback {
+  public static func pullback<LocalValue, LocalAction, GlobalValue, GlobalAction>(
+    reducer: @escaping Reducer<LocalValue, LocalAction>,
+    lens: WritableKeyPath<GlobalValue, LocalValue>,
+    prism: CasePath<GlobalAction, LocalAction>
+  ) -> Reducer<GlobalValue, GlobalAction> {
+    return { global, action in
+      guard let localAction = prism.extract(from: action) else { return }
+      reducer(&global[keyPath: lens], localAction)
+    }
+  }
+
+  public static func pullback<LocalValue, LocalAction, GlobalValue, GlobalAction>(
+    reducer: @escaping Reducer<LocalValue, LocalAction>,
+    lens: Optics.Lens<GlobalValue, LocalValue>,
+    prism: Optics.Prism<GlobalAction, LocalAction>
+  ) -> Reducer<GlobalValue, GlobalAction> {
+    return { global, action in
+      guard let localAction = prism.extract(action) else { return }
+      var next = lens.get(global)
+      reducer(&next, localAction)
+    }
+  }
+}

--- a/ComposableArchitecture/ComposableArchitecture/Sources/Reducers.swift
+++ b/ComposableArchitecture/ComposableArchitecture/Sources/Reducers.swift
@@ -1,0 +1,1 @@
+public typealias Reducer<Value, Action> = (inout Value, Action) -> Void

--- a/ComposableArchitecture/ComposableArchitecture/Tests/ExampleApp.swift
+++ b/ComposableArchitecture/ComposableArchitecture/Tests/ExampleApp.swift
@@ -1,0 +1,53 @@
+import ComposableArchitecture
+import Foundation
+
+struct AppState {
+  var counter = Counter.State()
+  var timer = Timer.State()
+}
+
+enum AppAction {
+  case global
+  case counter(Counter.Action)
+  case timer(Timer.Action)
+}
+
+enum Counter {
+  struct State {
+    var value = 0
+  }
+
+  enum Action {
+    case inc
+    case dec
+  }
+
+  static let reducer: Reducer<State, Action> = { state, action in
+    switch action {
+    case .inc:
+      state.value += 1
+    case .dec:
+      state.value -= 1
+    }
+  }
+}
+
+enum Timer {
+  struct State {
+    var value: Date?
+  }
+
+  enum Action {
+    case start
+    case stop
+  }
+
+  static let reducer: Reducer<State, Action> = { state, action in
+    switch action {
+    case .start:
+      state.value = Date()
+    case .stop:
+      state.value = nil
+    }
+  }
+}

--- a/ComposableArchitecture/ComposableArchitecture/Tests/PullbackTests.swift
+++ b/ComposableArchitecture/ComposableArchitecture/Tests/PullbackTests.swift
@@ -1,0 +1,34 @@
+import CasePaths
+import XCTest
+
+@testable import ComposableArchitecture
+
+class PullbackTests: XCTestCase {
+  func testThatItPrisms() {
+    var state = AppState()
+    let reducer = Pullback.pullback(
+      reducer: Counter.reducer,
+      lens: \AppState.counter,
+      prism: /AppAction.counter
+    )
+
+    reducer(&state, AppAction.timer(.start))
+
+    XCTAssert(state.counter.value == 0)
+    XCTAssertNil(state.timer.value)
+  }
+
+  func testThatItLenses() {
+    var state = AppState()
+    let reducer = Pullback.pullback(
+      reducer: Timer.reducer,
+      lens: \AppState.timer,
+      prism: /AppAction.timer
+    )
+
+    reducer(&state, AppAction.timer(.start))
+
+    XCTAssert(state.counter.value == 0)
+    XCTAssertNotNil(state.timer.value)
+  }
+}

--- a/ComposableArchitecture/Project.swift
+++ b/ComposableArchitecture/Project.swift
@@ -41,6 +41,7 @@ let p = Project(
       dependencies: [
         .package(product: "CasePaths"),
         .package(product: "Fuzzy"),
+        .target(name: "ComposableArchitecture"),
       ]
     ),
     Target(
@@ -52,6 +53,29 @@ let p = Project(
       sources: ["App/Tests/**"],
       resources: ["App/Resources/**"],
       dependencies: [.target(name: "App")]
+    ),
+    Target(
+      name: "ComposableArchitecture",
+      platform: .iOS,
+      product: .staticLibrary,
+      bundleId: "pointfree.composablearchitecture",
+      infoPlist: .default,
+      sources: ["ComposableArchitecture/Sources/**"],
+      dependencies: [
+        .package(product: "CasePaths")
+      ]
+    ),
+    Target(
+      name: "ComposableArchitectureTests",
+      platform: .iOS,
+      product: .unitTests,
+      bundleId: "pointfree.composablearchitecture",
+      infoPlist: .default,
+      sources: ["ComposableArchitecture/Tests/**"],
+      dependencies: [
+        .package(product: "CasePaths"),
+        .target(name: "ComposableArchitecture"),
+      ]
     ),
   ],
   additionalFiles: [


### PR DESCRIPTION
This adds an initial implementation of pullback along with a typealias for reducers. We're not using this operator yet in the app, but there are tests that show its usage. In general, pullback moves from one domain into another (and back), with the purpose of allowing composition in the "higher" domain.